### PR TITLE
Dependabot Prefix Commit Message

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: 'daily'
+      interval: daily
+    commit-message:
+      prefix: chore


### PR DESCRIPTION
Add the `chore` prefix to the Dependabot commit message and remove the single quotation marks in the YAML config.