### PR TITLE
Bump License Year to 2023

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2022 B201 Telematics Laboratory
+Copyright (c) 2020-2023 B201 Telematics Laboratory
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request simply just update the copyright year in the `LICENSE` file to 2023.