### PR TITLE
Fix Permission in Deployment Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     needs: compile
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pages: write
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
       pages: write
       id-token: write
     environment:


### PR DESCRIPTION
This pull request set the `actions` permission to `read` to fix the following deploy job issue in the main branch:

https://github.com/b201lab/template-proposal-ta-its/actions/runs/7270402331/job/19851091814

It also removes the `content` permission since it appears unnecessary during deployment.